### PR TITLE
Support for ${scanFolder} variable

### DIFF
--- a/src/main/java/com/github/bringking/maven/requirejs/OptimizeMojo.java
+++ b/src/main/java/com/github/bringking/maven/requirejs/OptimizeMojo.java
@@ -1,7 +1,10 @@
 package com.github.bringking.maven.requirejs;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +76,15 @@ public class OptimizeMojo extends AbstractMojo {
      * @parameter default-value=false
      */
     private boolean filterConfig;
+
+    /**
+     * If the 'deps' parameter in the config file should be generated
+     * automatically from the contents of this folder
+     * 
+     * @parameter
+     * @required
+     */
+    private File fillDepsFromFolder;
 
     /**
      * Skip optimization when this parameter is true.
@@ -171,6 +183,10 @@ public class OptimizeMojo extends AbstractMojo {
     @SuppressWarnings("rawtypes")
     private List<File> createBuildProfile() throws MojoExecutionException {
         if (filterConfig) {
+            String scannedDepList = null;
+            if (fillDepsFromFolder != null) {
+                scannedDepList = scanChildren(fillDepsFromFolder.toURI(), fillDepsFromFolder);
+            }
             List<File> filteredConfig = new ArrayList<File>();
             for (File configFile : configFiles) {
                 try {
@@ -182,6 +198,17 @@ public class OptimizeMojo extends AbstractMojo {
                     }
                     //TODO hardcoded encoding
                     mavenFileFilter.copyFile(configFile, currentFilteredConfig, true, project, new ArrayList(), true, "UTF8", session);
+                    if (scannedDepList != null) {
+                        RandomAccessFile raf = new RandomAccessFile(
+                                currentFilteredConfig, "rw");
+                        byte[] buffer = new byte[(int) raf.length()];
+                        raf.readFully(buffer);
+                        buffer = new String(buffer).replace("${scanFolder}",
+                                scannedDepList).getBytes();
+                        raf.seek(0);
+                        raf.write(buffer);
+                        raf.close();
+                    }
                     filteredConfig.add(currentFilteredConfig);
                 } catch (IOException e) {
                     throw new MojoExecutionException("Error creating filtered build file.", e);
@@ -193,6 +220,36 @@ public class OptimizeMojo extends AbstractMojo {
         } else {
             return configFiles;
         }
+    }
+
+    private String scanChildren(URI referenceURI, File currentFolder) {
+        File[] files = currentFolder.listFiles(new FileFilter() {
+            @Override
+            public boolean accept(File file) {
+                return file.getName().endsWith(".js") || file.isDirectory();
+            }
+        });
+
+        StringBuilder ret = new StringBuilder();
+        String separator = "";
+        if (files != null) {
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    ret.append(separator).append(
+                            scanChildren(referenceURI, file));
+                } else {
+                    String relativePath = referenceURI.relativize(file.toURI())
+                            .getPath();
+                    String relativePathWithoutExtension = relativePath
+                            .substring(0, relativePath.lastIndexOf('.'));
+                    ret.append(separator).append("\"")
+                            .append(relativePathWithoutExtension).append("\"");
+                }
+                separator = ",";
+            }
+        }
+
+        return ret.toString();
     }
 
     private String getNodeJsPath() {


### PR DESCRIPTION
I modified the plugin in order to be able to include all the .js in a folder. In my case, the modules are known only at run time, returned by a web service, so there is no list of dependencies anywhere.

With this change it is possible to include the variable ${scanFolder} like this:

```
...
name : "main",
deps: [${scanFolder}],
...
```

and it will be replaced by the comma separated list of modules found in the folder configured by the fillDepsFromFolder property in the pom.xml configuration:

```
<fillDepsFromFolder>${project.build.directory}/requirejs/web/modules</fillDepsFromFolder>
```

Tests are passing. Looking forward to reading your comments.
